### PR TITLE
Fix wrong link for array's homework

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 #### 1.1 [Знакомство с C++ (Hello World): структура программы, переменные и их типы](https://github.com/netology-code/cpps-homeworks/tree/main/1.1)
 #### 1.2 [Операторы ветвления. Логические операции](https://github.com/netology-code/cpps-homeworks/tree/main/1.2)
 #### 1.3 [Циклические конструкции](https://github.com/netology-code/cpps-homeworks/tree/main/1.3)
-#### 1.4 [Массивы](https://github.com/netology-code/cpps-homeworks/tree/main/1.10)
+#### 1.4 [Массивы](https://github.com/netology-code/cpps-homeworks/tree/main/1.4)
 #### 1.5 [Функции и их параметры. Рекурсия](https://github.com/netology-code/cpps-homeworks/tree/main/1.5)
 #### 1.6 [Модель памяти и хранение данных](https://github.com/netology-code/cpps-homeworks/tree/main/1.6)
 #### 1.7 [Область видимости переменных и типы памяти. Пространства имен](https://github.com/netology-code/cpps-homeworks/tree/main/1.7)


### PR DESCRIPTION
Из основного README.md была неправильная ссылка на ДЗ по массивам